### PR TITLE
feat: Add chainlog to DEFCON spells (SC-7883)

### DIFF
--- a/src/DEFCON-1.sol
+++ b/src/DEFCON-1.sol
@@ -61,16 +61,11 @@ contract IlkRegistryAbstract {
 import "lib/dss-interfaces/src/dss/ChainlogAbstract.sol";
 
 contract SpellAction {
-    // The contracts in this list should correspond to MCD core contracts, verify
+    // This address should correspond to the latest MCD Chainlog contract; verify
     //  against the current release list at:
-    //     https://changelog.makerdao.com/releases/mainnet/1.1.1/contracts.json
-    //
-    address constant MCD_VAT      = 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B;
-    address constant MCD_JUG      = 0x19c0976f590D67707E62397C87829d896Dc0f1F1;
-    address constant MCD_POT      = 0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7;
-    address constant FLIPPER_MOM  = 0xc4bE7F74Ee3743bDEd8E0fA218ee5cf06397f472;
-    address constant ILK_REGISTRY = 0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24;
-
+    //     https://changelog.makerdao.com/releases/mainnet/active/contracts.json
+    ChainlogAbstract constant CHANGELOG =
+        ChainlogAbstract(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
 
     // Many of the settings that change weekly rely on the rate accumulator
     // described at https://docs.makerdao.com/smart-contract-modules/rates-module
@@ -89,6 +84,11 @@ contract SpellAction {
     uint256 constant BLN = 10**9;
 
     function execute() external {
+        address constant MCD_VAT      = CHANGELOG.getAddress("MCD_VAT");
+        address constant MCD_JUG      = CHANGELOG.getAddress("MCD_JUG");
+        address constant MCD_POT      = CHANGELOG.getAddress("MCD_POT");
+        address constant FLIPPER_MOM  = CHANGELOG.getAddress("FLIPPER_MOM");
+        address constant ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
         uint256 totalLine = 0;
 
         // MCD Modifications

--- a/src/DEFCON-1.sol
+++ b/src/DEFCON-1.sol
@@ -15,6 +15,8 @@
 
 pragma solidity 0.5.12;
 
+import "lib/dss-interfaces/src/dss/ChainlogAbstract.sol";
+
 // https://github.com/dapphub/ds-pause
 contract DSPauseAbstract {
     function delay() public view returns (uint256);
@@ -57,8 +59,6 @@ contract IlkRegistryAbstract {
     function list() external view returns (bytes32[] memory);
     function flip(bytes32) external view returns (address);
 }
-
-import "lib/dss-interfaces/src/dss/ChainlogAbstract.sol";
 
 contract SpellAction {
     // This address should correspond to the latest MCD Chainlog contract; verify
@@ -147,6 +147,11 @@ contract SpellAction {
 }
 
 contract DssSpell {
+    // This address should correspond to the latest MCD Chainlog contract; verify
+    //  against the current release list at:
+    //     https://changelog.makerdao.com/releases/mainnet/active/contracts.json
+    ChainlogAbstract constant CHANGELOG =
+        ChainlogAbstract(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
 
     DSPauseAbstract  public pause;
     address          public action;
@@ -156,9 +161,9 @@ contract DssSpell {
     uint256          public expiration;
     bool             public done;
 
-    address constant MCD_PAUSE    = 0xbE286431454714F511008713973d3B053A2d38f3;
-    address constant FLIPPER_MOM  = 0xc4bE7F74Ee3743bDEd8E0fA218ee5cf06397f472;
-    address constant ILK_REGISTRY = 0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24;
+    address constant MCD_PAUSE    = CHANGELOG.getAddress("MCD_PAUSE");
+    address constant FLIPPER_MOM  = CHANGELOG.getAddress("FLIPPER_MOM");
+    address constant ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
 
     uint256 constant T2021_02_01_1200UTC = 1612180800;
 

--- a/src/DEFCON-1.sol
+++ b/src/DEFCON-1.sol
@@ -58,6 +58,8 @@ contract IlkRegistryAbstract {
     function flip(bytes32) external view returns (address);
 }
 
+import "lib/dss-interfaces/src/dss/ChainlogAbstract.sol";
+
 contract SpellAction {
     // The contracts in this list should correspond to MCD core contracts, verify
     //  against the current release list at:

--- a/src/DEFCON-1.sol
+++ b/src/DEFCON-1.sol
@@ -15,8 +15,6 @@
 
 pragma solidity 0.5.12;
 
-import "lib/dss-interfaces/src/dss/ChainlogAbstract.sol";
-
 // https://github.com/dapphub/ds-pause
 contract DSPauseAbstract {
     function delay() public view returns (uint256);
@@ -58,6 +56,11 @@ contract FlipperMomAbstract {
 contract IlkRegistryAbstract {
     function list() external view returns (bytes32[] memory);
     function flip(bytes32) external view returns (address);
+}
+
+// https://github.com/makerdao/dss-chain-log/blob/master/src/ChainLog.sol
+contract ChainlogAbstract {
+    function getAddress(bytes32) public view returns (address);
 }
 
 contract SpellAction {

--- a/src/DEFCON-1.sol
+++ b/src/DEFCON-1.sol
@@ -84,11 +84,11 @@ contract SpellAction {
     uint256 constant BLN = 10**9;
 
     function execute() external {
-        address constant MCD_VAT      = CHANGELOG.getAddress("MCD_VAT");
-        address constant MCD_JUG      = CHANGELOG.getAddress("MCD_JUG");
-        address constant MCD_POT      = CHANGELOG.getAddress("MCD_POT");
-        address constant FLIPPER_MOM  = CHANGELOG.getAddress("FLIPPER_MOM");
-        address constant ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
+        address MCD_VAT      = CHANGELOG.getAddress("MCD_VAT");
+        address MCD_JUG      = CHANGELOG.getAddress("MCD_JUG");
+        address MCD_POT      = CHANGELOG.getAddress("MCD_POT");
+        address FLIPPER_MOM  = CHANGELOG.getAddress("FLIPPER_MOM");
+        address ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
         uint256 totalLine = 0;
 
         // MCD Modifications
@@ -161,16 +161,13 @@ contract DssSpell {
     uint256          public expiration;
     bool             public done;
 
-    address constant MCD_PAUSE    = CHANGELOG.getAddress("MCD_PAUSE");
-    address constant FLIPPER_MOM  = CHANGELOG.getAddress("FLIPPER_MOM");
-    address constant ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
-
     uint256 constant T2021_02_01_1200UTC = 1612180800;
 
     // Provides a descriptive tag for bot consumption
     string constant public description = "DEFCON-1 Emergency Spell";
 
     constructor() public {
+        address MCD_PAUSE = CHANGELOG.getAddress("MCD_PAUSE");
         sig = abi.encodeWithSignature("execute()");
         action = address(new SpellAction());
         bytes32 _tag;
@@ -184,6 +181,8 @@ contract DssSpell {
     function schedule() public {
         require(now <= expiration, "This contract has expired");
         require(eta == 0, "This spell has already been scheduled");
+        address ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
+        address FLIPPER_MOM  = CHANGELOG.getAddress("FLIPPER_MOM");
         eta = now + pause.delay();
         pause.plot(action, tag, sig, eta);
 

--- a/src/DEFCON-1.t.sol
+++ b/src/DEFCON-1.t.sol
@@ -73,8 +73,8 @@ contract DssSpellTest is DSTest, DSMath {
          PotAbstract(0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7);
     JugAbstract jug =
          JugAbstract(0x19c0976f590D67707E62397C87829d896Dc0f1F1);
-    MKRAbstract gov =
-         MKRAbstract(0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2);
+    DSTokenAbstract gov =
+         DSTokenAbstract(0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2);
     IlkRegistryAbstract registry =
         IlkRegistryAbstract(0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24);
 

--- a/src/DEFCON-2.sol
+++ b/src/DEFCON-2.sol
@@ -84,10 +84,10 @@ contract SpellAction {
     uint256 constant BLN = 10**9;
 
     function execute() external {
-        address constant MCD_VAT      = CHANGELOG.getAddress("MCD_VAT");
-        address constant MCD_JUG      = CHANGELOG.getAddress("MCD_JUG");
-        address constant MCD_POT      = CHANGELOG.getAddress("MCD_POT");
-        address constant ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
+        address MCD_VAT      = CHANGELOG.getAddress("MCD_VAT");
+        address MCD_JUG      = CHANGELOG.getAddress("MCD_JUG");
+        address MCD_POT      = CHANGELOG.getAddress("MCD_POT");
+        address ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
         uint256 totalLine = 0;
 
         // MCD Modifications
@@ -164,15 +164,13 @@ contract DssSpell {
     uint256          public expiration;
     bool             public done;
 
-    address constant MCD_PAUSE    = CHANGELOG.getAddress("MCD_PAUSE");
-    address constant ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
-
     uint256 constant T2021_02_01_1200UTC = 1612180800;
 
     // Provides a descriptive tag for bot consumption
     string constant public description = "DEFCON-2 Emergency Spell";
 
     constructor() public {
+        address MCD_PAUSE = CHANGELOG.getAddress("MCD_PAUSE");
         sig = abi.encodeWithSignature("execute()");
         action = address(new SpellAction());
         bytes32 _tag;
@@ -186,6 +184,7 @@ contract DssSpell {
     function schedule() public {
         require(now <= expiration, "This contract has expired");
         require(eta == 0, "This spell has already been scheduled");
+        address ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
         eta = now + pause.delay();
         pause.plot(action, tag, sig, eta);
     }

--- a/src/DEFCON-2.sol
+++ b/src/DEFCON-2.sol
@@ -67,9 +67,6 @@ contract SpellAction {
     ChainlogAbstract constant CHANGELOG =
         ChainlogAbstract(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
 
-
-
-
     // Many of the settings that change weekly rely on the rate accumulator
     // described at https://docs.makerdao.com/smart-contract-modules/rates-module
     // To check this yourself, use the following rate calculation (example 8%):

--- a/src/DEFCON-2.sol
+++ b/src/DEFCON-2.sol
@@ -15,6 +15,8 @@
 
 pragma solidity 0.5.12;
 
+import "lib/dss-interfaces/src/dss/ChainlogAbstract.sol";
+
 // https://github.com/dapphub/ds-pause
 contract DSPauseAbstract {
     function delay() public view returns (uint256);
@@ -59,14 +61,13 @@ contract IlkRegistryAbstract {
 }
 
 contract SpellAction {
-    // The contracts in this list should correspond to MCD core contracts, verify
+    // This address should correspond to the latest MCD Chainlog contract; verify
     //  against the current release list at:
-    //     https://changelog.makerdao.com/releases/mainnet/1.1.1/contracts.json
-    //
-    address constant MCD_VAT      = 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B;
-    address constant MCD_JUG      = 0x19c0976f590D67707E62397C87829d896Dc0f1F1;
-    address constant MCD_POT      = 0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7;
-    address constant ILK_REGISTRY = 0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24;
+    //     https://changelog.makerdao.com/releases/mainnet/active/contracts.json
+    ChainlogAbstract constant CHANGELOG =
+        ChainlogAbstract(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
+
+
 
 
     // Many of the settings that change weekly rely on the rate accumulator
@@ -86,6 +87,10 @@ contract SpellAction {
     uint256 constant BLN = 10**9;
 
     function execute() external {
+        address constant MCD_VAT      = CHANGELOG.getAddress("MCD_VAT");
+        address constant MCD_JUG      = CHANGELOG.getAddress("MCD_JUG");
+        address constant MCD_POT      = CHANGELOG.getAddress("MCD_POT");
+        address constant ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
         uint256 totalLine = 0;
 
         // MCD Modifications
@@ -148,6 +153,11 @@ contract SpellAction {
 }
 
 contract DssSpell {
+    // This address should correspond to the latest MCD Chainlog contract; verify
+    //  against the current release list at:
+    //     https://changelog.makerdao.com/releases/mainnet/active/contracts.json
+    ChainlogAbstract constant CHANGELOG =
+        ChainlogAbstract(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
 
     DSPauseAbstract  public pause;
     address          public action;
@@ -157,8 +167,8 @@ contract DssSpell {
     uint256          public expiration;
     bool             public done;
 
-    address constant MCD_PAUSE    = 0xbE286431454714F511008713973d3B053A2d38f3;
-    address constant ILK_REGISTRY = 0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24;
+    address constant MCD_PAUSE    = CHANGELOG.getAddress("MCD_PAUSE");
+    address constant ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
 
     uint256 constant T2021_02_01_1200UTC = 1612180800;
 

--- a/src/DEFCON-2.sol
+++ b/src/DEFCON-2.sol
@@ -15,8 +15,6 @@
 
 pragma solidity 0.5.12;
 
-import "lib/dss-interfaces/src/dss/ChainlogAbstract.sol";
-
 // https://github.com/dapphub/ds-pause
 contract DSPauseAbstract {
     function delay() public view returns (uint256);
@@ -58,6 +56,11 @@ contract FlipperMomAbstract {
 contract IlkRegistryAbstract {
     function list() external view returns (bytes32[] memory);
     function flip(bytes32) external view returns (address);
+}
+
+// https://github.com/makerdao/dss-chain-log/blob/master/src/ChainLog.sol
+contract ChainlogAbstract {
+    function getAddress(bytes32) public view returns (address);
 }
 
 contract SpellAction {

--- a/src/DEFCON-2.t.sol
+++ b/src/DEFCON-2.t.sol
@@ -73,8 +73,8 @@ contract DssSpellTest is DSTest, DSMath {
          PotAbstract(0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7);
     JugAbstract jug =
          JugAbstract(0x19c0976f590D67707E62397C87829d896Dc0f1F1);
-    MKRAbstract gov =
-         MKRAbstract(0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2);
+    DSTokenAbstract gov =
+         DSTokenAbstract(0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2);
     IlkRegistryAbstract registry =
         IlkRegistryAbstract(0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24);
 

--- a/src/DEFCON-3.sol
+++ b/src/DEFCON-3.sol
@@ -15,6 +15,8 @@
 
 pragma solidity 0.5.12;
 
+import "lib/dss-interfaces/src/dss/ChainlogAbstract.sol";
+
 // https://github.com/dapphub/ds-pause
 contract DSPauseAbstract {
     function delay() public view returns (uint256);
@@ -59,15 +61,11 @@ contract IlkRegistryAbstract {
 }
 
 contract SpellAction {
-    // The contracts in this list should correspond to MCD core contracts, verify
+    // This address should correspond to the latest MCD Chainlog contract; verify
     //  against the current release list at:
-    //     https://changelog.makerdao.com/releases/mainnet/1.1.1/contracts.json
-    //
-    address constant MCD_VAT      = 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B;
-    address constant MCD_JUG      = 0x19c0976f590D67707E62397C87829d896Dc0f1F1;
-    address constant MCD_POT      = 0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7;
-    address constant ILK_REGISTRY = 0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24;
-
+    //     https://changelog.makerdao.com/releases/mainnet/active/contracts.json
+    ChainlogAbstract constant CHANGELOG =
+        ChainlogAbstract(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
 
     // Many of the settings that change weekly rely on the rate accumulator
     // described at https://docs.makerdao.com/smart-contract-modules/rates-module
@@ -86,6 +84,10 @@ contract SpellAction {
     uint256 constant BLN = 10**9;
 
     function execute() external {
+        address constant MCD_VAT      = CHANGELOG.getAddress("MCD_VAT");
+        address constant MCD_JUG      = CHANGELOG.getAddress("MCD_JUG");
+        address constant MCD_POT      = CHANGELOG.getAddress("MCD_POT");
+        address constant ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
         uint256 totalLine = 0;
 
         // MCD Modifications
@@ -144,6 +146,11 @@ contract SpellAction {
 }
 
 contract DssSpell {
+    // This address should correspond to the latest MCD Chainlog contract; verify
+    //  against the current release list at:
+    //     https://changelog.makerdao.com/releases/mainnet/active/contracts.json
+    ChainlogAbstract constant CHANGELOG =
+        ChainlogAbstract(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
 
     DSPauseAbstract  public pause;
     address          public action;
@@ -153,8 +160,8 @@ contract DssSpell {
     uint256          public expiration;
     bool             public done;
 
-    address constant MCD_PAUSE    = 0xbE286431454714F511008713973d3B053A2d38f3;
-    address constant ILK_REGISTRY = 0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24;
+    address constant MCD_PAUSE    = CHANGELOG.getAddress("MCD_PAUSE");
+    address constant ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
 
     uint256 constant T2021_02_01_1200UTC = 1612180800;
 

--- a/src/DEFCON-3.sol
+++ b/src/DEFCON-3.sol
@@ -15,8 +15,6 @@
 
 pragma solidity 0.5.12;
 
-import "lib/dss-interfaces/src/dss/ChainlogAbstract.sol";
-
 // https://github.com/dapphub/ds-pause
 contract DSPauseAbstract {
     function delay() public view returns (uint256);
@@ -58,6 +56,11 @@ contract FlipperMomAbstract {
 contract IlkRegistryAbstract {
     function list() external view returns (bytes32[] memory);
     function flip(bytes32) external view returns (address);
+}
+
+// https://github.com/makerdao/dss-chain-log/blob/master/src/ChainLog.sol
+contract ChainlogAbstract {
+    function getAddress(bytes32) public view returns (address);
 }
 
 contract SpellAction {

--- a/src/DEFCON-3.sol
+++ b/src/DEFCON-3.sol
@@ -84,10 +84,10 @@ contract SpellAction {
     uint256 constant BLN = 10**9;
 
     function execute() external {
-        address constant MCD_VAT      = CHANGELOG.getAddress("MCD_VAT");
-        address constant MCD_JUG      = CHANGELOG.getAddress("MCD_JUG");
-        address constant MCD_POT      = CHANGELOG.getAddress("MCD_POT");
-        address constant ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
+        address MCD_VAT      = CHANGELOG.getAddress("MCD_VAT");
+        address MCD_JUG      = CHANGELOG.getAddress("MCD_JUG");
+        address MCD_POT      = CHANGELOG.getAddress("MCD_POT");
+        address ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
         uint256 totalLine = 0;
 
         // MCD Modifications
@@ -160,15 +160,13 @@ contract DssSpell {
     uint256          public expiration;
     bool             public done;
 
-    address constant MCD_PAUSE    = CHANGELOG.getAddress("MCD_PAUSE");
-    address constant ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
-
     uint256 constant T2021_02_01_1200UTC = 1612180800;
 
     // Provides a descriptive tag for bot consumption
     string constant public description = "DEFCON-3 Emergency Spell";
 
     constructor() public {
+        address MCD_PAUSE = CHANGELOG.getAddress("MCD_PAUSE");
         sig = abi.encodeWithSignature("execute()");
         action = address(new SpellAction());
         bytes32 _tag;
@@ -182,6 +180,7 @@ contract DssSpell {
     function schedule() public {
         require(now <= expiration, "This contract has expired");
         require(eta == 0, "This spell has already been scheduled");
+        address ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
         eta = now + pause.delay();
         pause.plot(action, tag, sig, eta);
     }

--- a/src/DEFCON-3.t.sol
+++ b/src/DEFCON-3.t.sol
@@ -73,8 +73,8 @@ contract DssSpellTest is DSTest, DSMath {
          PotAbstract(0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7);
     JugAbstract jug =
          JugAbstract(0x19c0976f590D67707E62397C87829d896Dc0f1F1);
-    MKRAbstract gov =
-         MKRAbstract(0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2);
+    DSTokenAbstract gov =
+         DSTokenAbstract(0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2);
     IlkRegistryAbstract registry =
         IlkRegistryAbstract(0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24);
 

--- a/src/DEFCON-5.sol
+++ b/src/DEFCON-5.sol
@@ -57,7 +57,7 @@ contract SpellAction {
     uint256 constant BLN = 10**9;
 
     function execute() external {
-        address constant MCD_VAT = CHANGELOG.getAddress("MCD_VAT");
+        address MCD_VAT = CHANGELOG.getAddress("MCD_VAT");
         require(VatAbstract(MCD_VAT).wards(address(this)) == 1, "no-access");
     }
 }
@@ -77,16 +77,13 @@ contract DssSpell {
     uint256          public expiration;
     bool             public done;
 
-    address constant MCD_PAUSE    = CHANGELOG.getAddress("MCD_PAUSE");
-    address constant FLIPPER_MOM  = CHANGELOG.getAddress("FLIPPER_MOM");
-    address constant ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
-
     uint256 constant T2021_02_01_1200UTC = 1612180800;
 
     // Provides a descriptive tag for bot consumption
     string constant public description = "DEFCON-5 Emergency Spell";
 
     constructor() public {
+        address MCD_PAUSE = CHANGELOG.getAddress("MCD_PAUSE");
         sig = abi.encodeWithSignature("execute()");
         action = address(new SpellAction());
         bytes32 _tag;
@@ -100,6 +97,8 @@ contract DssSpell {
     function schedule() public {
         require(now <= expiration, "This contract has expired");
         require(eta == 0, "This spell has already been scheduled");
+        address FLIPPER_MOM  = CHANGELOG.getAddress("FLIPPER_MOM");
+        address ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
         eta = now + pause.delay();
         pause.plot(action, tag, sig, eta);
 

--- a/src/DEFCON-5.sol
+++ b/src/DEFCON-5.sol
@@ -15,6 +15,8 @@
 
 pragma solidity 0.5.12;
 
+import "lib/dss-interfaces/src/dss/ChainlogAbstract.sol";
+
 // https://github.com/dapphub/ds-pause
 contract DSPauseAbstract {
     function delay() public view returns (uint256);
@@ -40,11 +42,11 @@ contract IlkRegistryAbstract {
 }
 
 contract SpellAction {
-    // The contracts in this list should correspond to MCD core contracts, verify
+    // This address should correspond to the latest MCD Chainlog contract; verify
     //  against the current release list at:
-    //     https://changelog.makerdao.com/releases/mainnet/1.1.1/contracts.json
-    //
-    address constant MCD_VAT = 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B;
+    //     https://changelog.makerdao.com/releases/mainnet/active/contracts.json
+    ChainlogAbstract constant CHANGELOG =
+        ChainlogAbstract(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
 
     // Common orders of magnitude needed in spells
     //
@@ -55,11 +57,18 @@ contract SpellAction {
     uint256 constant BLN = 10**9;
 
     function execute() external {
+        address constant MCD_VAT = CHANGELOG.getAddress("MCD_VAT");
         require(VatAbstract(MCD_VAT).wards(address(this)) == 1, "no-access");
     }
 }
 
 contract DssSpell {
+    // This address should correspond to the latest MCD Chainlog contract; verify
+    //  against the current release list at:
+    //     https://changelog.makerdao.com/releases/mainnet/active/contracts.json
+    ChainlogAbstract constant CHANGELOG =
+        ChainlogAbstract(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
+
     DSPauseAbstract  public pause;
     address          public action;
     bytes32          public tag;
@@ -68,9 +77,9 @@ contract DssSpell {
     uint256          public expiration;
     bool             public done;
 
-    address constant MCD_PAUSE    = 0xbE286431454714F511008713973d3B053A2d38f3;
-    address constant FLIPPER_MOM  = 0xc4bE7F74Ee3743bDEd8E0fA218ee5cf06397f472;
-    address constant ILK_REGISTRY = 0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24;
+    address constant MCD_PAUSE    = CHANGELOG.getAddress("MCD_PAUSE");
+    address constant FLIPPER_MOM  = CHANGELOG.getAddress("FLIPPER_MOM");
+    address constant ILK_REGISTRY = CHANGELOG.getAddress("ILK_REGISTRY");
 
     uint256 constant T2021_02_01_1200UTC = 1612180800;
 

--- a/src/DEFCON-5.sol
+++ b/src/DEFCON-5.sol
@@ -15,8 +15,6 @@
 
 pragma solidity 0.5.12;
 
-import "lib/dss-interfaces/src/dss/ChainlogAbstract.sol";
-
 // https://github.com/dapphub/ds-pause
 contract DSPauseAbstract {
     function delay() public view returns (uint256);
@@ -39,6 +37,11 @@ contract FlipperMomAbstract {
 contract IlkRegistryAbstract {
     function list() external view returns (bytes32[] memory);
     function flip(bytes32) external view returns (address);
+}
+
+// https://github.com/makerdao/dss-chain-log/blob/master/src/ChainLog.sol
+contract ChainlogAbstract {
+    function getAddress(bytes32) public view returns (address);
 }
 
 contract SpellAction {

--- a/src/DEFCON-5.t.sol
+++ b/src/DEFCON-5.t.sol
@@ -71,8 +71,8 @@ contract DssSpellTest is DSTest, DSMath {
                 PotAbstract(0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7);
     JugAbstract jug =
                 JugAbstract(0x19c0976f590D67707E62397C87829d896Dc0f1F1);
-    MKRAbstract gov =
-                MKRAbstract(0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2);
+    DSTokenAbstract gov =
+                DSTokenAbstract(0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2);
     IlkRegistryAbstract registry =
         IlkRegistryAbstract(0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24);
 


### PR DESCRIPTION
Added the chainlog contract to all DEFCON spells to avoid the need of manually updating the addresses of other MCD contracts.