### PR TITLE
fix: Updates DEFCON spells post FlipperMom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 all    :; dapp --use solc:0.5.12 build
 clean  :; dapp clean
 test   :; ./test-dsspell.sh
-deploy :; dapp create DssTests
+deploy :; dapp create DssSpell

--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ Fast access governance spells.
 
 Run `./test-dssspell.sh` with an `ETH_RPC_URL` set to Mainnet node
 
+## mainnet (updated 2021-03-03)
+```
+DEFCON-1: 0x0A352a23060cc58b05c4EEbA9F6E85Dbd37D7D91
+DEFCON-2: 0x454ba3b18b71e1d4903C2E3052D554856b30ebE4
+DEFCON-3: 0x993DEFd0337D8BaE7bE3D25597Be738a27b5d9d2
+DEFCON-5: 0x639145eE45fE1e70BBa61B4b67288d5E42A1A79B
+```

--- a/src/DEFCON-1.sol
+++ b/src/DEFCON-1.sol
@@ -44,6 +44,7 @@ contract VatAbstract {
 // https://github.com/makerdao/dss/blob/master/src/flip.sol
 contract FlipAbstract {
     function file(bytes32, uint256) external;
+    function wards(address) external view returns (uint256);
 }
 
 // https://github.com/makerdao/flipper-mom/blob/master/src/FlipperMom.sol
@@ -194,22 +195,14 @@ contract DssSpell {
         bytes32[] memory ilks = registry.list();
 
         for (uint i = 0; i < ilks.length; i++) {
-            // skip the rest of the loop for the following ilks:
-            //
-            if (ilks[i] == "USDC-A"   ||
-                ilks[i] == "USDC-B"   ||
-                ilks[i] == "TUSD-A"   ||
-                ilks[i] == "PAXUSD-A" ||
-                ilks[i] == "GUSD-A"   ||
-                ilks[i] == "PSM-USDC-A"
-             ) { continue; }
-
             // Disable all collateral liquidations
             //
             // This change will prevent liquidations across all collateral types
             // and is colloquially referred to as the circuit breaker.
             //
-            FlipperMomAbstract(FLIPPER_MOM).deny(registry.flip(ilks[i]));
+            if (FlipAbstract(registry.flip(ilks[i])).wards(FLIPPER_MOM) == 1) {
+                FlipperMomAbstract(FLIPPER_MOM).deny(registry.flip(ilks[i]));
+            }
         }
     }
 

--- a/src/DEFCON-1.sol
+++ b/src/DEFCON-1.sol
@@ -158,7 +158,7 @@ contract DssSpell {
     address constant FLIPPER_MOM  = 0xc4bE7F74Ee3743bDEd8E0fA218ee5cf06397f472;
     address constant ILK_REGISTRY = 0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24;
 
-    uint256 constant T2021_02_01_1200UTC = 1612180800;
+    uint256 constant T2021_07_01_1200UTC = 1625140800;
 
     // Provides a descriptive tag for bot consumption
     string constant public description = "DEFCON-1 Emergency Spell";
@@ -171,7 +171,7 @@ contract DssSpell {
         assembly { _tag := extcodehash(_action) }
         tag = _tag;
         pause = DSPauseAbstract(MCD_PAUSE);
-        expiration = T2021_02_01_1200UTC;
+        expiration = T2021_07_01_1200UTC;
     }
 
     function schedule() public {
@@ -186,6 +186,16 @@ contract DssSpell {
         bytes32[] memory ilks = registry.list();
 
         for (uint i = 0; i < ilks.length; i++) {
+            // skip the rest of the loop for the following ilks:
+            //
+            if (ilks[i] == "USDC-A"   ||
+                ilks[i] == "USDC-B"   ||
+                ilks[i] == "TUSD-A"   ||
+                ilks[i] == "PAXUSD-A" ||
+                ilks[i] == "GUSD-A"   ||
+                ilks[i] == "PSM-USDC-A"
+             ) { continue; }
+
             // Disable all collateral liquidations
             //
             // This change will prevent liquidations across all collateral types

--- a/src/DEFCON-1.t.sol
+++ b/src/DEFCON-1.t.sol
@@ -99,13 +99,7 @@ contract DssSpellTest is DSTest, DSMath {
             expiration: T2021_07_01_1200UTC
         });
 
-        afterSpell = SystemValues({
-            dsr: 1000000000000000000000000000,
-            Line: vat.Line() + (50 * MLN * RAD),
-            pauseDelay: pause.delay(),
-            expiration: T2021_07_01_1200UTC
-        });
-
+        uint256 sumlines;
         bytes32[] memory ilks = registry.list();
 
         for(uint i = 0; i < ilks.length; i++) {
@@ -134,7 +128,15 @@ contract DssSpellTest is DSTest, DSMath {
                 afterSpell.collaterals["USDC-B"].liquidations = 0;
                 afterSpell.collaterals["USDC-B"].duty = duty;
             }
+            sumlines += line;
         }
+
+        afterSpell = SystemValues({
+            dsr: 1000000000000000000000000000,
+            Line: sumlines + (50 * MLN * RAD),
+            pauseDelay: pause.delay(),
+            expiration: T2021_07_01_1200UTC
+        });
     }
 
     function vote() private {

--- a/src/DEFCON-1.t.sol
+++ b/src/DEFCON-1.t.sol
@@ -28,7 +28,7 @@ contract Hevm {
 
 contract DssSpellTest is DSTest, DSMath {
     // Replace with mainnet spell address to test against live
-    address constant MAINNET_SPELL = address(0);
+    address constant MAINNET_SPELL = address(0x0A352a23060cc58b05c4EEbA9F6E85Dbd37D7D91);
 
     // Common orders of magnitude needed in spells
     //

--- a/src/DEFCON-1.t.sol
+++ b/src/DEFCON-1.t.sol
@@ -28,9 +28,7 @@ contract Hevm {
 
 contract DssSpellTest is DSTest, DSMath {
     // Replace with mainnet spell address to test against live
-    address constant MAINNET_SPELL = address(
-        0xF5F016fD2ba03FcD6f56199327D4E28AC4923E6C
-    );
+    address constant MAINNET_SPELL = address(0);
 
     // Common orders of magnitude needed in spells
     //
@@ -85,7 +83,7 @@ contract DssSpellTest is DSTest, DSMath {
         bytes20(uint160(uint256(keccak256('hevm cheat code'))));
 
     // expiration time for this DEFCON spell
-    uint256 constant public T2021_02_01_1200UTC = 1612180800;
+    uint256 constant public T2021_07_01_1200UTC = 1625140800;
 
     function setUp() public {
         hevm = Hevm(address(CHEAT_CODE));
@@ -98,14 +96,14 @@ contract DssSpellTest is DSTest, DSMath {
             dsr: pot.dsr(),
             Line: vat.Line(),
             pauseDelay: pause.delay(),
-            expiration: T2021_02_01_1200UTC
+            expiration: T2021_07_01_1200UTC
         });
 
         afterSpell = SystemValues({
             dsr: 1000000000000000000000000000,
             Line: vat.Line() + (50 * MLN * RAD),
             pauseDelay: pause.delay(),
-            expiration: T2021_02_01_1200UTC
+            expiration: T2021_07_01_1200UTC
         });
 
         bytes32[] memory ilks = registry.list();

--- a/src/DEFCON-2.sol
+++ b/src/DEFCON-2.sol
@@ -160,7 +160,7 @@ contract DssSpell {
     address constant MCD_PAUSE    = 0xbE286431454714F511008713973d3B053A2d38f3;
     address constant ILK_REGISTRY = 0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24;
 
-    uint256 constant T2021_02_01_1200UTC = 1612180800;
+    uint256 constant T2021_07_01_1200UTC = 1625140800;
 
     // Provides a descriptive tag for bot consumption
     string constant public description = "DEFCON-2 Emergency Spell";
@@ -173,7 +173,7 @@ contract DssSpell {
         assembly { _tag := extcodehash(_action) }
         tag = _tag;
         pause = DSPauseAbstract(MCD_PAUSE);
-        expiration = T2021_02_01_1200UTC;
+        expiration = T2021_07_01_1200UTC;
     }
 
     function schedule() public {

--- a/src/DEFCON-2.t.sol
+++ b/src/DEFCON-2.t.sol
@@ -99,13 +99,7 @@ contract DssSpellTest is DSTest, DSMath {
             expiration: T2021_07_01_1200UTC
         });
 
-        afterSpell = SystemValues({
-            dsr: 1000000000000000000000000000,
-            Line: vat.Line() + (50 * MLN * RAD),
-            pauseDelay: pause.delay(),
-            expiration: T2021_07_01_1200UTC
-        });
-
+        uint256 sumlines;
         bytes32[] memory ilks = registry.list();
 
         for(uint i = 0; i < ilks.length; i++) {
@@ -133,7 +127,15 @@ contract DssSpellTest is DSTest, DSMath {
                     line + (50 * MLN * RAD);
                 afterSpell.collaterals["USDC-B"].duty = duty;
             }
+            sumlines += line;
         }
+
+        afterSpell = SystemValues({
+            dsr: 1000000000000000000000000000,
+            Line: sumlines + (50 * MLN * RAD),
+            pauseDelay: pause.delay(),
+            expiration: T2021_07_01_1200UTC
+        });
     }
 
     function vote() private {

--- a/src/DEFCON-2.t.sol
+++ b/src/DEFCON-2.t.sol
@@ -28,7 +28,7 @@ contract Hevm {
 
 contract DssSpellTest is DSTest, DSMath {
     // Replace with mainnet spell address to test against live
-    address constant MAINNET_SPELL = address(0);
+    address constant MAINNET_SPELL = address(0x454ba3b18b71e1d4903C2E3052D554856b30ebE4);
 
     // Common orders of magnitude needed in spells
     //

--- a/src/DEFCON-2.t.sol
+++ b/src/DEFCON-2.t.sol
@@ -28,9 +28,7 @@ contract Hevm {
 
 contract DssSpellTest is DSTest, DSMath {
     // Replace with mainnet spell address to test against live
-    address constant MAINNET_SPELL = address(
-        0xcAAdcFC74404D54987D0763fa46484C74D166e92
-    );
+    address constant MAINNET_SPELL = address(0);
 
     // Common orders of magnitude needed in spells
     //
@@ -85,7 +83,7 @@ contract DssSpellTest is DSTest, DSMath {
         bytes20(uint160(uint256(keccak256('hevm cheat code'))));
 
     // expiration time for this DEFCON spell
-    uint256 constant public T2021_02_01_1200UTC = 1612180800;
+    uint256 constant public T2021_07_01_1200UTC = 1625140800;
 
     function setUp() public {
         hevm = Hevm(address(CHEAT_CODE));
@@ -98,14 +96,14 @@ contract DssSpellTest is DSTest, DSMath {
             dsr: pot.dsr(),
             Line: vat.Line(),
             pauseDelay: pause.delay(),
-            expiration: T2021_02_01_1200UTC
+            expiration: T2021_07_01_1200UTC
         });
 
         afterSpell = SystemValues({
             dsr: 1000000000000000000000000000,
             Line: vat.Line() + (50 * MLN * RAD),
             pauseDelay: pause.delay(),
-            expiration: T2021_02_01_1200UTC
+            expiration: T2021_07_01_1200UTC
         });
 
         bytes32[] memory ilks = registry.list();

--- a/src/DEFCON-3.sol
+++ b/src/DEFCON-3.sol
@@ -156,7 +156,7 @@ contract DssSpell {
     address constant MCD_PAUSE    = 0xbE286431454714F511008713973d3B053A2d38f3;
     address constant ILK_REGISTRY = 0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24;
 
-    uint256 constant T2021_02_01_1200UTC = 1612180800;
+    uint256 constant T2021_07_01_1200UTC = 1625140800;
 
     // Provides a descriptive tag for bot consumption
     string constant public description = "DEFCON-3 Emergency Spell";
@@ -169,7 +169,7 @@ contract DssSpell {
         assembly { _tag := extcodehash(_action) }
         tag = _tag;
         pause = DSPauseAbstract(MCD_PAUSE);
-        expiration = T2021_02_01_1200UTC;
+        expiration = T2021_07_01_1200UTC;
     }
 
     function schedule() public {

--- a/src/DEFCON-3.t.sol
+++ b/src/DEFCON-3.t.sol
@@ -99,13 +99,7 @@ contract DssSpellTest is DSTest, DSMath {
             expiration: T2021_07_01_1200UTC
         });
 
-        afterSpell = SystemValues({
-            dsr: 1000000000000000000000000000,
-            Line: vat.Line() + (50 * MLN * RAD),
-            pauseDelay: pause.delay(),
-            expiration: T2021_07_01_1200UTC
-        });
-
+        uint256 sumlines;
         bytes32[] memory ilks = registry.list();
 
         for(uint i = 0; i < ilks.length; i++) {
@@ -133,7 +127,15 @@ contract DssSpellTest is DSTest, DSMath {
                     line + (50 * MLN * RAD);
                 afterSpell.collaterals["USDC-B"].duty = duty;
             }
+            sumlines += line;
         }
+
+        afterSpell = SystemValues({
+            dsr: 1000000000000000000000000000,
+            Line: sumlines + (50 * MLN * RAD),
+            pauseDelay: pause.delay(),
+            expiration: T2021_07_01_1200UTC
+        });
     }
 
     function vote() private {

--- a/src/DEFCON-3.t.sol
+++ b/src/DEFCON-3.t.sol
@@ -28,9 +28,7 @@ contract Hevm {
 
 contract DssSpellTest is DSTest, DSMath {
     // Replace with mainnet spell address to test against live
-    address constant MAINNET_SPELL = address(
-        0xf9f794CE408b206fd63FC2CA9D2f7224B24d9516
-    );
+    address constant MAINNET_SPELL = address(0);
 
     // Common orders of magnitude needed in spells
     //
@@ -85,7 +83,7 @@ contract DssSpellTest is DSTest, DSMath {
         bytes20(uint160(uint256(keccak256('hevm cheat code'))));
 
     // expiration time for this DEFCON spell
-    uint256 constant public T2021_02_01_1200UTC = 1612180800;
+    uint256 constant public T2021_07_01_1200UTC = 1625140800;
 
     function setUp() public {
         hevm = Hevm(address(CHEAT_CODE));
@@ -98,14 +96,14 @@ contract DssSpellTest is DSTest, DSMath {
             dsr: pot.dsr(),
             Line: vat.Line(),
             pauseDelay: pause.delay(),
-            expiration: T2021_02_01_1200UTC
+            expiration: T2021_07_01_1200UTC
         });
 
         afterSpell = SystemValues({
             dsr: 1000000000000000000000000000,
             Line: vat.Line() + (50 * MLN * RAD),
             pauseDelay: pause.delay(),
-            expiration: T2021_02_01_1200UTC
+            expiration: T2021_07_01_1200UTC
         });
 
         bytes32[] memory ilks = registry.list();

--- a/src/DEFCON-3.t.sol
+++ b/src/DEFCON-3.t.sol
@@ -28,7 +28,7 @@ contract Hevm {
 
 contract DssSpellTest is DSTest, DSMath {
     // Replace with mainnet spell address to test against live
-    address constant MAINNET_SPELL = address(0);
+    address constant MAINNET_SPELL = address(0x993DEFd0337D8BaE7bE3D25597Be738a27b5d9d2);
 
     // Common orders of magnitude needed in spells
     //

--- a/src/DEFCON-5.sol
+++ b/src/DEFCON-5.sol
@@ -27,6 +27,11 @@ contract VatAbstract {
     function wards(address) external view returns (uint256);
 }
 
+// https://github.com/makerdao/dss/blob/master/src/flip.sol
+contract FlipAbstract {
+    function wards(address) external view returns (uint256);
+}
+
 // https://github.com/makerdao/flipper-mom/blob/master/src/FlipperMom.sol
 contract FlipperMomAbstract {
     function rely(address) external;
@@ -111,23 +116,14 @@ contract DssSpell {
         bytes32[] memory ilks = registry.list();
 
         for (uint i = 0; i < ilks.length; i++) {
-            // skip the rest of the loop for the following ilks:
-            //
-            if (
-                ilks[i] == "USDC-A"   ||
-                ilks[i] == "USDC-B"   ||
-                ilks[i] == "TUSD-A"   ||
-                ilks[i] == "PAXUSD-A" ||
-                ilks[i] == "GUSD-A"   ||
-                ilks[i] == "PSM-USDC-A"
-            ) { continue; }
-
             // Enable collateral liquidations
             //
             // This change will enable liquidations for collateral types
             // and is colloquially referred to as the "circuit breaker".
             //
-            FlipperMomAbstract(FLIPPER_MOM).rely(registry.flip(ilks[i]));
+            if (FlipAbstract(registry.flip(ilks[i])).wards(FLIPPER_MOM) == 1) {
+                FlipperMomAbstract(FLIPPER_MOM).rely(registry.flip(ilks[i]));
+            }
         }
     }
 

--- a/src/DEFCON-5.sol
+++ b/src/DEFCON-5.sol
@@ -72,7 +72,7 @@ contract DssSpell {
     address constant FLIPPER_MOM  = 0xc4bE7F74Ee3743bDEd8E0fA218ee5cf06397f472;
     address constant ILK_REGISTRY = 0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24;
 
-    uint256 constant T2021_02_01_1200UTC = 1612180800;
+    uint256 constant T2021_07_01_1200UTC = 1625140800;
 
     // Provides a descriptive tag for bot consumption
     string constant public description = "DEFCON-5 Emergency Spell";
@@ -85,7 +85,7 @@ contract DssSpell {
         assembly { _tag := extcodehash(_action) }
         tag = _tag;
         pause = DSPauseAbstract(MCD_PAUSE);
-        expiration = T2021_02_01_1200UTC;
+        expiration = T2021_07_01_1200UTC;
     }
 
     function schedule() public {
@@ -102,12 +102,13 @@ contract DssSpell {
         for (uint i = 0; i < ilks.length; i++) {
             // skip the rest of the loop for the following ilks:
             //
-            if (ilks[i] == "USDC-A"   ||
+            if (
+                ilks[i] == "USDC-A"   ||
                 ilks[i] == "USDC-B"   ||
                 ilks[i] == "TUSD-A"   ||
                 ilks[i] == "PAXUSD-A" ||
                 ilks[i] == "GUSD-A"   ||
-                ilks[i] == 0x50534d2d555344432d4100000000000000000000000000000000000000000000
+                ilks[i] == "PSM-USDC-A"
             ) { continue; }
 
             // Enable collateral liquidations

--- a/src/DEFCON-5.t.sol
+++ b/src/DEFCON-5.t.sol
@@ -128,6 +128,8 @@ contract DssSpellTest is DSTest, DSMath {
             });
         }
 
+        afterSpell.collaterals["PSM-USDC-A"].liquidations = 0;
+        afterSpell.collaterals["UNIV2DAIUSDC-A"].liquidations = 0;
         afterSpell.collaterals["USDC-A"].liquidations = 0;
         afterSpell.collaterals["USDC-B"].liquidations = 0;
         afterSpell.collaterals["TUSD-A"].liquidations = 0;

--- a/src/DEFCON-5.t.sol
+++ b/src/DEFCON-5.t.sol
@@ -83,7 +83,7 @@ contract DssSpellTest is DSTest, DSMath {
         bytes20(uint160(uint256(keccak256('hevm cheat code'))));
 
     // expiration time for this DEFCON spell
-    uint256 constant public T2021_02_01_1200UTC = 1612180800;
+    uint256 constant public T2021_07_01_1200UTC = 1625140800;
 
     function setUp() public {
         hevm = Hevm(address(CHEAT_CODE));
@@ -96,14 +96,14 @@ contract DssSpellTest is DSTest, DSMath {
             dsr: pot.dsr(),
             Line: vat.Line(),
             pauseDelay: pause.delay(),
-            expiration: T2021_02_01_1200UTC
+            expiration: T2021_07_01_1200UTC
         });
 
         afterSpell = SystemValues({
             dsr: pot.dsr(),
             Line: vat.Line(),
             pauseDelay: pause.delay(),
-            expiration: T2021_02_01_1200UTC
+            expiration: T2021_07_01_1200UTC
         });
 
         bytes32[] memory ilks = registry.list();

--- a/src/DEFCON-5.t.sol
+++ b/src/DEFCON-5.t.sol
@@ -28,7 +28,7 @@ contract Hevm {
 
 contract DssSpellTest is DSTest, DSMath {
     // Replace with mainnet spell address to test against live
-    address constant MAINNET_SPELL = address(0);
+    address constant MAINNET_SPELL = address(0x639145eE45fE1e70BBa61B4b67288d5E42A1A79B);
 
     // Common orders of magnitude needed in spells
     //


### PR DESCRIPTION
Now that the circuit breaker is off for stablecoin Vaults, we can't just blindly call the FlipperMom on them.  This is just a quick update in case we need a DEFCON spell in the next few days, a more complete update is coming soon.

If Maker governance needs to trigger the circuit breaker, simply deploy `DEFCON-1`, verify it, and put it in the voting portal.