### PR TITLE
Patch liq 2.0

### DIFF
--- a/archive/DEFCON-1.t.sol
+++ b/archive/DEFCON-1.t.sol
@@ -11,7 +11,7 @@ contract Hevm { function warp(uint) public; }
 contract DssSpellTest is DSTest, DSMath {
 
     // Replace with mainnet spell address to test against live
-    address constant MAINNET_SPELL = 0xE8ccAc37E45a0cC6aD65999A71c0AF7D1Fb06209;
+    address constant MAINNET_SPELL = address(0);
     uint256 constant public T2020_07_01_1200UTC = 1593604800;
 
     struct SystemValues {

--- a/src/DEFCON-1.sol
+++ b/src/DEFCON-1.sol
@@ -56,7 +56,8 @@ contract FlipperMomAbstract {
 // https://github.com/makerdao/ilk-registry/blob/master/src/IlkRegistry.sol
 contract IlkRegistryAbstract {
     function list() external view returns (bytes32[] memory);
-    function flip(bytes32) external view returns (address);
+    function xlip(bytes32) external view returns (address);
+    function class(bytes32) external view returns (uint256);
 }
 
 // https://github.com/makerdao/dss-chain-log/blob/master/src/ChainLog.sol
@@ -200,8 +201,8 @@ contract DssSpell {
             // This change will prevent liquidations across all collateral types
             // and is colloquially referred to as the circuit breaker.
             //
-            if (FlipAbstract(registry.flip(ilks[i])).wards(FLIPPER_MOM) == 1) {
-                FlipperMomAbstract(FLIPPER_MOM).deny(registry.flip(ilks[i]));
+            if (registry.class(ilks[i]) == 2 && FlipAbstract(registry.xlip(ilks[i])).wards(FLIPPER_MOM) == 1) {
+                FlipperMomAbstract(FLIPPER_MOM).deny(registry.xlip(ilks[i]));
             }
         }
     }

--- a/src/DEFCON-2.t.sol
+++ b/src/DEFCON-2.t.sol
@@ -28,7 +28,7 @@ contract Hevm {
 
 contract DssSpellTest is DSTest, DSMath {
     // Replace with mainnet spell address to test against live
-    address constant MAINNET_SPELL = address(0x454ba3b18b71e1d4903C2E3052D554856b30ebE4);
+    address constant MAINNET_SPELL = address(0);
 
     // Common orders of magnitude needed in spells
     //
@@ -62,19 +62,21 @@ contract DssSpellTest is DSTest, DSMath {
     DSPauseAbstract pause =
         DSPauseAbstract(0xbE286431454714F511008713973d3B053A2d38f3);
     DSChiefAbstract chief =
-         DSChiefAbstract(0x0a3f6849f78076aefaDf113F5BED87720274dDC0);
+        DSChiefAbstract(0x0a3f6849f78076aefaDf113F5BED87720274dDC0);
     VatAbstract vat =
-         VatAbstract(0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B);
+        VatAbstract(0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B);
     CatAbstract cat =
-         CatAbstract(0xa5679C04fc3d9d8b0AaB1F0ab83555b301cA70Ea);
+        CatAbstract(0xa5679C04fc3d9d8b0AaB1F0ab83555b301cA70Ea);
+    DogAbstract dog =
+        DogAbstract(0x135954d155898D42C90D2a57824C690e0c7BEf1B);
     PotAbstract pot =
-         PotAbstract(0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7);
+        PotAbstract(0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7);
     JugAbstract jug =
-         JugAbstract(0x19c0976f590D67707E62397C87829d896Dc0f1F1);
+        JugAbstract(0x19c0976f590D67707E62397C87829d896Dc0f1F1);
     DSTokenAbstract gov =
-         DSTokenAbstract(0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2);
+        DSTokenAbstract(0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2);
     IlkRegistryAbstract registry =
-        IlkRegistryAbstract(0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24);
+        IlkRegistryAbstract(0x5a464C28D19848f44199D003BeF5ecc87d090F87);
 
     DssSpell spell;
 
@@ -105,21 +107,26 @@ contract DssSpellTest is DSTest, DSMath {
         for(uint i = 0; i < ilks.length; i++) {
             (,,, uint256 line,) = vat.ilks(ilks[i]);
             (uint256 duty,) = jug.ilks(ilks[i]);
-            FlipAbstract flip = FlipAbstract(registry.flip(ilks[i]));
 
-            beforeSpell.collaterals[ilks[i]] = CollateralValues({
-                line: line,
-                duty: duty,
-                tau: flip.tau(),
-                liquidations: flip.wards(address(cat))
-            });
+            if (registry.class(ilks[i]) == 2) {
 
-            afterSpell.collaterals[ilks[i]] = CollateralValues({
-                line: line,
-                duty: 1000000000000000000000000000,
-                tau: 24 hours,
-                liquidations: flip.wards(address(cat))
-            });
+                FlipAbstract flip = FlipAbstract(registry.xlip(ilks[i]));
+
+                beforeSpell.collaterals[ilks[i]] = CollateralValues({
+                    line: line,
+                    duty: duty,
+                    tau: flip.tau(),
+                    liquidations: flip.wards(address(cat))
+                });
+
+                afterSpell.collaterals[ilks[i]] = CollateralValues({
+                    line: line,
+                    duty: 1000000000000000000000000000,
+                    tau: 24 hours,
+                    liquidations: flip.wards(address(cat))
+                });
+            }
+
 
             if (ilks[i] == "USDC-B") {
                 // USDC-B emergency parameters
@@ -204,16 +211,18 @@ contract DssSpellTest is DSTest, DSMath {
         bytes32 ilk,
         SystemValues storage values
     ) internal {
-        FlipAbstract flip = FlipAbstract(registry.flip(ilk));
+        if (registry.class(ilk) == 2) {
+            FlipAbstract flip = FlipAbstract(registry.xlip(ilk));
 
-        (uint256 duty,) = jug.ilks(ilk);
-        assertEq(duty, values.collaterals[ilk].duty);
+            (uint256 duty,) = jug.ilks(ilk);
+            assertEq(duty, values.collaterals[ilk].duty);
 
-        (,,, uint256 line,) = vat.ilks(ilk);
-        assertEq(line, values.collaterals[ilk].line);
+            (,,, uint256 line,) = vat.ilks(ilk);
+            assertEq(line, values.collaterals[ilk].line);
 
-        assertEq(uint256(flip.tau()), values.collaterals[ilk].tau);
-        assertEq(flip.wards(address(cat)), values.collaterals[ilk].liquidations);
+            assertEq(uint256(flip.tau()), values.collaterals[ilk].tau);
+            assertEq(flip.wards(address(cat)), values.collaterals[ilk].liquidations);
+        }
     }
 
     function testDEFCON2() public {

--- a/src/DEFCON-3.sol
+++ b/src/DEFCON-3.sol
@@ -55,7 +55,7 @@ contract FlipperMomAbstract {
 // https://github.com/makerdao/ilk-registry/blob/master/src/IlkRegistry.sol
 contract IlkRegistryAbstract {
     function list() external view returns (bytes32[] memory);
-    function flip(bytes32) external view returns (address);
+    function xlip(bytes32) external view returns (address);
 }
 
 // https://github.com/makerdao/dss-chain-log/blob/master/src/ChainLog.sol
@@ -111,6 +111,7 @@ contract SpellAction {
         bytes32[] memory ilks = registry.list();
 
         for (uint i = 0; i < ilks.length; i++) {
+
             // skip the rest of the loop for the following ilks:
             //
             if (ilks[i] == "USDC-B") {

--- a/src/DEFCON-3.t.sol
+++ b/src/DEFCON-3.t.sol
@@ -28,7 +28,7 @@ contract Hevm {
 
 contract DssSpellTest is DSTest, DSMath {
     // Replace with mainnet spell address to test against live
-    address constant MAINNET_SPELL = address(0x993DEFd0337D8BaE7bE3D25597Be738a27b5d9d2);
+    address constant MAINNET_SPELL = address(0);
 
     // Common orders of magnitude needed in spells
     //
@@ -62,19 +62,21 @@ contract DssSpellTest is DSTest, DSMath {
     DSPauseAbstract pause =
         DSPauseAbstract(0xbE286431454714F511008713973d3B053A2d38f3);
     DSChiefAbstract chief =
-         DSChiefAbstract(0x0a3f6849f78076aefaDf113F5BED87720274dDC0);
+        DSChiefAbstract(0x0a3f6849f78076aefaDf113F5BED87720274dDC0);
     VatAbstract vat =
-         VatAbstract(0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B);
+        VatAbstract(0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B);
     CatAbstract cat =
-         CatAbstract(0xa5679C04fc3d9d8b0AaB1F0ab83555b301cA70Ea);
+        CatAbstract(0xa5679C04fc3d9d8b0AaB1F0ab83555b301cA70Ea);
+    DogAbstract dog =
+        DogAbstract(0x135954d155898D42C90D2a57824C690e0c7BEf1B);
     PotAbstract pot =
-         PotAbstract(0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7);
+        PotAbstract(0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7);
     JugAbstract jug =
-         JugAbstract(0x19c0976f590D67707E62397C87829d896Dc0f1F1);
+        JugAbstract(0x19c0976f590D67707E62397C87829d896Dc0f1F1);
     DSTokenAbstract gov =
-         DSTokenAbstract(0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2);
+        DSTokenAbstract(0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2);
     IlkRegistryAbstract registry =
-        IlkRegistryAbstract(0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24);
+        IlkRegistryAbstract(0x5a464C28D19848f44199D003BeF5ecc87d090F87);
 
     DssSpell spell;
 
@@ -105,21 +107,25 @@ contract DssSpellTest is DSTest, DSMath {
         for(uint i = 0; i < ilks.length; i++) {
             (,,, uint256 line,) = vat.ilks(ilks[i]);
             (uint256 duty,) = jug.ilks(ilks[i]);
-            FlipAbstract flip = FlipAbstract(registry.flip(ilks[i]));
 
-            beforeSpell.collaterals[ilks[i]] = CollateralValues({
-                line: line,
-                duty: duty,
-                tau: flip.tau(),
-                liquidations: flip.wards(address(cat))
-            });
+            if (registry.class(ilks[i]) == 2) {
 
-            afterSpell.collaterals[ilks[i]] = CollateralValues({
-                line: line,
-                duty: 1000000000000000000000000000,
-                tau: flip.tau(),
-                liquidations: flip.wards(address(cat))
-            });
+                FlipAbstract flip = FlipAbstract(registry.xlip(ilks[i]));
+
+                beforeSpell.collaterals[ilks[i]] = CollateralValues({
+                    line: line,
+                    duty: duty,
+                    tau: flip.tau(),
+                    liquidations: flip.wards(address(cat))
+                });
+
+                afterSpell.collaterals[ilks[i]] = CollateralValues({
+                    line: line,
+                    duty: 1000000000000000000000000000,
+                    tau: flip.tau(),
+                    liquidations: flip.wards(address(cat))
+                });
+            }
 
             if (ilks[i] == "USDC-B") {
                 // USDC-B emergency parameters
@@ -203,16 +209,18 @@ contract DssSpellTest is DSTest, DSMath {
         bytes32 ilk,
         SystemValues storage values
     ) internal {
-        FlipAbstract flip = FlipAbstract(registry.flip(ilk));
+        if (registry.class(ilk) == 2) {
+            FlipAbstract flip = FlipAbstract(registry.xlip(ilk));
 
-        (uint256 duty,) = jug.ilks(ilk);
-        assertEq(duty, values.collaterals[ilk].duty);
+            (uint256 duty,) = jug.ilks(ilk);
+            assertEq(duty, values.collaterals[ilk].duty);
 
-        (,,, uint256 line,) = vat.ilks(ilk);
-        assertEq(line, values.collaterals[ilk].line);
+            (,,, uint256 line,) = vat.ilks(ilk);
+            assertEq(line, values.collaterals[ilk].line);
 
-        assertEq(uint256(flip.tau()), values.collaterals[ilk].tau);
-        assertEq(flip.wards(address(cat)), values.collaterals[ilk].liquidations);
+            assertEq(uint256(flip.tau()), values.collaterals[ilk].tau);
+            assertEq(flip.wards(address(cat)), values.collaterals[ilk].liquidations);
+        }
     }
 
     function testDEFCON3() public {

--- a/src/DEFCON-5.sol
+++ b/src/DEFCON-5.sol
@@ -41,7 +41,8 @@ contract FlipperMomAbstract {
 // https://github.com/makerdao/ilk-registry/blob/master/src/IlkRegistry.sol
 contract IlkRegistryAbstract {
     function list() external view returns (bytes32[] memory);
-    function flip(bytes32) external view returns (address);
+    function xlip(bytes32) external view returns (address);
+    function class(bytes32) external view returns (uint256);
 }
 
 // https://github.com/makerdao/dss-chain-log/blob/master/src/ChainLog.sol
@@ -121,8 +122,8 @@ contract DssSpell {
             // This change will enable liquidations for collateral types
             // and is colloquially referred to as the "circuit breaker".
             //
-            if (FlipAbstract(registry.flip(ilks[i])).wards(FLIPPER_MOM) == 1) {
-                FlipperMomAbstract(FLIPPER_MOM).rely(registry.flip(ilks[i]));
+            if (registry.class(ilks[i]) == 2 && FlipAbstract(registry.xlip(ilks[i])).wards(FLIPPER_MOM) == 1) {
+                FlipperMomAbstract(FLIPPER_MOM).rely(registry.xlip(ilks[i]));
             }
         }
     }

--- a/src/DEFCON-5.t.sol
+++ b/src/DEFCON-5.t.sol
@@ -28,7 +28,7 @@ contract Hevm {
 
 contract DssSpellTest is DSTest, DSMath {
     // Replace with mainnet spell address to test against live
-    address constant MAINNET_SPELL = address(0x639145eE45fE1e70BBa61B4b67288d5E42A1A79B);
+    address constant MAINNET_SPELL = address(0);
 
     // Common orders of magnitude needed in spells
     //
@@ -60,21 +60,23 @@ contract DssSpellTest is DSTest, DSMath {
     Hevm hevm;
 
     DSPauseAbstract pause =
-            DSPauseAbstract(0xbE286431454714F511008713973d3B053A2d38f3);
+        DSPauseAbstract(0xbE286431454714F511008713973d3B053A2d38f3);
     DSChiefAbstract chief =
-            DSChiefAbstract(0x0a3f6849f78076aefaDf113F5BED87720274dDC0);
+        DSChiefAbstract(0x0a3f6849f78076aefaDf113F5BED87720274dDC0);
     VatAbstract vat =
-                VatAbstract(0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B);
+        VatAbstract(0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B);
     CatAbstract cat =
-                CatAbstract(0xa5679C04fc3d9d8b0AaB1F0ab83555b301cA70Ea);
+        CatAbstract(0xa5679C04fc3d9d8b0AaB1F0ab83555b301cA70Ea);
+    DogAbstract dog =
+        DogAbstract(0x135954d155898D42C90D2a57824C690e0c7BEf1B);
     PotAbstract pot =
-                PotAbstract(0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7);
+        PotAbstract(0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7);
     JugAbstract jug =
-                JugAbstract(0x19c0976f590D67707E62397C87829d896Dc0f1F1);
+        JugAbstract(0x19c0976f590D67707E62397C87829d896Dc0f1F1);
     DSTokenAbstract gov =
-                DSTokenAbstract(0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2);
+        DSTokenAbstract(0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2);
     IlkRegistryAbstract registry =
-        IlkRegistryAbstract(0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24);
+        IlkRegistryAbstract(0x5a464C28D19848f44199D003BeF5ecc87d090F87);
 
     DssSpell spell;
 
@@ -111,21 +113,24 @@ contract DssSpellTest is DSTest, DSMath {
         for(uint i = 0; i < ilks.length; i++) {
             (,,, uint256 line,) = vat.ilks(ilks[i]);
             (uint256 duty,) = jug.ilks(ilks[i]);
-            FlipAbstract flip = FlipAbstract(registry.flip(ilks[i]));
 
-            beforeSpell.collaterals[ilks[i]] = CollateralValues({
-                line: line,
-                duty: duty,
-                tau: flip.tau(),
-                liquidations: flip.wards(address(cat))
-            });
+            if (registry.class(ilks[i]) == 2) {
+                FlipAbstract flip = FlipAbstract(registry.xlip(ilks[i]));
 
-            afterSpell.collaterals[ilks[i]] = CollateralValues({
-                line: line,
-                duty: duty,
-                tau: flip.tau(),
-                liquidations: 1
-            });
+                beforeSpell.collaterals[ilks[i]] = CollateralValues({
+                    line: line,
+                    duty: duty,
+                    tau: flip.tau(),
+                    liquidations: flip.wards(address(cat))
+                });
+
+                afterSpell.collaterals[ilks[i]] = CollateralValues({
+                    line: line,
+                    duty: duty,
+                    tau: flip.tau(),
+                    liquidations: 1
+                });
+            }
         }
 
         afterSpell.collaterals["PSM-USDC-A"].liquidations = 0;
@@ -203,16 +208,18 @@ contract DssSpellTest is DSTest, DSMath {
         bytes32 ilk,
         SystemValues storage values
     ) internal {
-        FlipAbstract flip = FlipAbstract(registry.flip(ilk));
+        if (registry.class(ilk) == 2) {
+            FlipAbstract flip = FlipAbstract(registry.xlip(ilk));
 
-        (uint256 duty,) = jug.ilks(ilk);
-        assertEq(duty, values.collaterals[ilk].duty);
+            (uint256 duty,) = jug.ilks(ilk);
+            assertEq(duty, values.collaterals[ilk].duty);
 
-        (,,, uint256 line,) = vat.ilks(ilk);
-        assertEq(line, values.collaterals[ilk].line);
+            (,,, uint256 line,) = vat.ilks(ilk);
+            assertEq(line, values.collaterals[ilk].line);
 
-        assertEq(uint256(flip.tau()), values.collaterals[ilk].tau);
-        assertEq(flip.wards(address(cat)), values.collaterals[ilk].liquidations);
+            assertEq(uint256(flip.tau()), values.collaterals[ilk].tau);
+            assertEq(flip.wards(address(cat)), values.collaterals[ilk].liquidations);
+        }
     }
 
     function testDEFCON5() public {


### PR DESCRIPTION
Updates to use the Liquidations 2.0 code.

This is a patch fix that will resolve the failing CI, however after working with this it's clear that this repo is out of date and that we're going to need to re-envision and re-write these contracts to work with all of the liquidations 2.0 and RWA collaterals.